### PR TITLE
Prepend the Next.js basePath to index card hrefs

### DIFF
--- a/.changeset/chatty-trains-explode.md
+++ b/.changeset/chatty-trains-explode.md
@@ -1,0 +1,5 @@
+---
+'@primer/doctocat-nextjs': patch
+---
+
+Fix lack of `basePath` support on index cards. `href` now prepends the `basePath`.

--- a/packages/theme/components/layout/index-cards/IndexCards.tsx
+++ b/packages/theme/components/layout/index-cards/IndexCards.tsx
@@ -3,6 +3,7 @@ import {Card, Grid} from '@primer/react-brand'
 import {DocsItem} from '../../../types'
 import {useColorMode} from '../../context/color-modes/useColorMode'
 import type {StaticImageData} from 'next/image'
+import Link from 'next/link'
 import placeholderDarkOneThumb from './images/dark-1.png'
 import placeholderDarkTwoThumb from './images/dark-2.png'
 import placeholderDarkThreeThumb from './images/dark-3.png'
@@ -90,11 +91,13 @@ export function IndexCards({route, folderData}: IndexCardsProps) {
 
         return (
           <Grid.Column span={{xsmall: 12, small: 12, medium: 12, large: 6, xlarge: 4}} key={item.frontMatter.title}>
-            <Card href={item.route} hasBorder>
-              <Card.Image src={thumbnailUrl} alt="" aspectRatio="4:3" />
-              <Card.Heading>{item.frontMatter.title}</Card.Heading>
-              {item.frontMatter.description && <Card.Description>{item.frontMatter.description}</Card.Description>}
-            </Card>
+            <Link legacyBehavior passHref href={item.route}>
+              <Card href="#" hasBorder>
+                <Card.Image src={thumbnailUrl} alt="" aspectRatio="4:3" />
+                <Card.Heading>{item.frontMatter.title}</Card.Heading>
+                {item.frontMatter.description && <Card.Description>{item.frontMatter.description}</Card.Description>}
+              </Card>
+            </Link>
           </Grid.Column>
         )
       })}


### PR DESCRIPTION
Fixes bug where index cards 404 on Next.js builds that specify a `basePath` (like Primer sites).

Testing:

1. Go to [this preview link](https://primer-3378719fe1-41738341.drafts.github.io/content-example)
2. Click on a card
3. Observe that it goes to right location and doesn't 404