### PR TITLE
Increase contrast of code syntax highlights

### DIFF
--- a/.changeset/tame-moons-fry.md
+++ b/.changeset/tame-moons-fry.md
@@ -1,0 +1,8 @@
+---
+'@primer/doctocat-nextjs': patch
+---
+
+Increase contrast of all `code span` syntax highlights in code fences on light mode.
+
+Before: 4.31:1 AA (fails WCAG AA)
+After: 5.03:1 AA (passes WCAG AA)

--- a/packages/theme/css/global.css
+++ b/packages/theme/css/global.css
@@ -5,8 +5,8 @@
 html,
 body {
   background-color: var(--brand-color-canvas-default) !important;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji';
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
 [data-color-mode='dark'] {
@@ -37,6 +37,11 @@ code {
 
 code span {
   color: var(--shiki-light);
+}
+
+/* Override shiki-light keyword color for better contrast */
+code span[style*='--shiki-light:#D73A49'] {
+  --shiki-light: var(--base-color-scale-red-5) !important;
 }
 
 [data-color-mode='dark'] code span {


### PR DESCRIPTION
Towards https://github.com/github/accessibility-audits/issues/15010

Increases contrast of syntax highlights to `code span` selectors through Shiki.

Overrides the default light mode value with a high specificiity selector. 

<img width="1125" height="413" alt="Screenshot 2026-02-19 at 15 43 22" src="https://github.com/user-attachments/assets/33728e82-f446-45da-ade8-d590db1db7bf" />
