### PR TITLE
Add an llms.txt generator to improve Agent discovery and token efficiency

### DIFF
--- a/.changeset/shiny-pans-help.md
+++ b/.changeset/shiny-pans-help.md
@@ -20,4 +20,4 @@ export async function GET() {
 }
 ```
 
-Important: Ensure that `title`, `description` and `keyword` fields are populated in your contents frontmatter.
+Important: Ensure that `title`, `description` and `keywords` fields are populated in your content's frontmatter.

--- a/.changeset/shiny-pans-help.md
+++ b/.changeset/shiny-pans-help.md
@@ -1,0 +1,23 @@
+---
+'@primer/doctocat-nextjs': minor
+---
+
+Added support for generating [llms.txt](https://llmstxt.org/) at build time. This file will make your site's content easily discoverable by Agentic AI tools like GitHub Copilot.
+
+To enable this feature, create `app/llms.txt/route.ts`:
+
+```ts
+import {generateLLMsTxt} from '@primer/doctocat-nextjs/llms'
+
+export const dynamic = 'force-static'
+
+export async function GET() {
+  const content = await generateLLMsTxt()
+
+  return new Response(content, {
+    headers: {'Content-Type': 'text/plain; charset=utf-8'},
+  })
+}
+```
+
+Important: Ensure that `title`, `description` and `keyword` fields are populated in your contents frontmatter.

--- a/packages/site/app/llms.txt/route.ts
+++ b/packages/site/app/llms.txt/route.ts
@@ -1,0 +1,11 @@
+import {generateLLMsTxt} from '@primer/doctocat-nextjs/llms'
+
+export const dynamic = 'force-static'
+
+export async function GET() {
+  const content = await generateLLMsTxt()
+
+  return new Response(content, {
+    headers: {'Content-Type': 'text/plain; charset=utf-8'},
+  })
+}

--- a/packages/site/content/getting-started/introduction.mdx
+++ b/packages/site/content/getting-started/introduction.mdx
@@ -105,7 +105,41 @@ description: My page description
 ---
 ```
 
-## 8. Deploy to GitHub Pages
+## 8. Optional: Add an LLMs.txt file
+
+Add an [`llms.txt`](https://llmstxt.org/) file to make your site content easily discoverable to AI tools like GitHub Copilot. This file will be automatically generated at build time, and help your Agents discover your content much more efficiently.
+
+To enable this feature, you simply need to copy the following code into a new file at the following location: `app/llms.txt/route.ts`:
+
+```ts live
+import {generateLLMsTxt} from '@primer/doctocat-nextjs/llms'
+
+export const dynamic = 'force-static'
+
+export async function GET() {
+  const content = await generateLLMsTxt()
+
+  return new Response(content, {
+    headers: {'Content-Type': 'text/plain; charset=utf-8'},
+  })
+}
+```
+
+The title and description are automatically inferred from your homepage frontmatter.
+
+The resulting `/llms.txt` will list every page on your site with its title, description, and any keywords from your frontmatter.
+
+To help discoverability, be sure to add relevant `keywords` to your page frontmatter:
+
+```md
+---
+title: My page title
+description: My page description
+keywords: ['synonyms', 'alternative', 'search terms']
+---
+```
+
+## 9. Deploy to GitHub Pages
 
 After you've customized the content of your site, you're ready to deploy. There are many ways to deploy your site, but we currently use [GitHub Pages](https://pages.github.com/) for most of our sites, and have found it to be an easy way to get sites up and running quickly.
 

--- a/packages/site/next-env.d.ts
+++ b/packages/site/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/theme/llms.test.ts
+++ b/packages/theme/llms.test.ts
@@ -1,0 +1,179 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest'
+import type {MdxFile, Folder, MetaJsonFile, PageMapItem} from 'nextra'
+
+vi.mock('nextra/page-map', () => ({
+  getPageMap: vi.fn(),
+}))
+
+import {getPageMap} from 'nextra/page-map'
+import {generateLLMsTxt} from './llms'
+
+const mockGetPageMap = vi.mocked(getPageMap)
+
+function createMockMdxFile(overrides: Partial<MdxFile> & {name: string; route: string}): MdxFile {
+  return {frontMatter: {}, ...overrides}
+}
+
+function createMockFolder(name: string, route: string, children: PageMapItem[]): Folder {
+  return {name, route, children}
+}
+
+const metaFile: MetaJsonFile = {data: {'index.mdx': 'Home'}}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  delete process.env.NEXT_PUBLIC_SITE_TITLE
+})
+
+describe('generateLLMsTxt', () => {
+  it('infers title and description from homepage frontmatter', async () => {
+    mockGetPageMap.mockResolvedValue([
+      createMockMdxFile({name: 'index', route: '/', frontMatter: {title: 'My Docs', description: 'A docs site'}}),
+    ])
+
+    const result = await generateLLMsTxt()
+
+    expect(result).toContain('# My Docs')
+    expect(result).toContain('> A docs site')
+  })
+
+  it('falls back to NEXT_PUBLIC_SITE_TITLE env var', async () => {
+    process.env.NEXT_PUBLIC_SITE_TITLE = 'Env Title'
+    mockGetPageMap.mockResolvedValue([createMockMdxFile({name: 'index', route: '/'})])
+
+    const result = await generateLLMsTxt()
+
+    expect(result).toContain('# Env Title')
+  })
+
+  it('falls back to "Documentation" when no title source exists', async () => {
+    mockGetPageMap.mockResolvedValue([createMockMdxFile({name: 'index', route: '/'})])
+
+    const result = await generateLLMsTxt()
+
+    expect(result).toContain('# Documentation')
+    expect(result).not.toContain('>')
+  })
+
+  it('lists pages with title and description', async () => {
+    mockGetPageMap.mockResolvedValue([
+      createMockMdxFile({name: 'index', route: '/', frontMatter: {title: 'Home'}}),
+      createMockMdxFile({name: 'guide', route: '/guide', frontMatter: {title: 'Guide', description: 'A guide'}}),
+    ])
+
+    const result = await generateLLMsTxt()
+
+    expect(result).toContain('- [Home](/)')
+    expect(result).toContain('- [Guide](/guide): A guide')
+  })
+
+  it('appends tab-label to title', async () => {
+    mockGetPageMap.mockResolvedValue([
+      createMockMdxFile({name: 'index', route: '/', frontMatter: {title: 'Home'}}),
+      createMockMdxFile({
+        name: 'button',
+        route: '/button',
+        frontMatter: {title: 'Button', 'tab-label': 'React'},
+      }),
+    ])
+
+    const result = await generateLLMsTxt()
+
+    expect(result).toContain('- [Button - React](/button)')
+  })
+
+  it('includes keywords when present', async () => {
+    mockGetPageMap.mockResolvedValue([
+      createMockMdxFile({name: 'index', route: '/', frontMatter: {title: 'Home'}}),
+      createMockMdxFile({
+        name: 'testimonials',
+        route: '/testimonials',
+        frontMatter: {title: 'Testimonials', keywords: ['quotes', 'reviews']},
+      }),
+    ])
+
+    const result = await generateLLMsTxt()
+
+    expect(result).toContain('- [Testimonials](/testimonials) (quotes, reviews)')
+  })
+
+  it('omits keywords when array is empty', async () => {
+    mockGetPageMap.mockResolvedValue([
+      createMockMdxFile({name: 'index', route: '/', frontMatter: {title: 'Home'}}),
+      createMockMdxFile({name: 'page', route: '/page', frontMatter: {title: 'Page', keywords: []}}),
+    ])
+
+    const result = await generateLLMsTxt()
+
+    const line = result.split('\n').find(l => l.includes('[Page]'))
+    expect(line).toBe('- [Page](/page)')
+  })
+
+  it('recursively collects pages from nested folders', async () => {
+    mockGetPageMap.mockResolvedValue([
+      createMockMdxFile({name: 'index', route: '/', frontMatter: {title: 'Home'}}),
+      createMockFolder('components', '/components', [
+        createMockMdxFile({name: 'button', route: '/components/button', frontMatter: {title: 'Button'}}),
+        createMockFolder('patterns', '/components/patterns', [
+          createMockMdxFile({name: 'forms', route: '/components/patterns/forms', frontMatter: {title: 'Forms'}}),
+        ]),
+      ]),
+    ])
+
+    const result = await generateLLMsTxt()
+
+    expect(result).toContain('- [Button](/components/button)')
+    expect(result).toContain('- [Forms](/components/patterns/forms)')
+  })
+
+  it('skips MetaJsonFile entries', async () => {
+    mockGetPageMap.mockResolvedValue([
+      createMockMdxFile({name: 'index', route: '/', frontMatter: {title: 'Home'}}),
+      metaFile,
+    ])
+
+    const result = await generateLLMsTxt()
+
+    expect(result).not.toContain('index.mdx')
+    expect(result).toContain('- [Home](/)')
+  })
+
+  it('uses file name when title is missing from frontmatter', async () => {
+    mockGetPageMap.mockResolvedValue([
+      createMockMdxFile({name: 'index', route: '/', frontMatter: {title: 'Home'}}),
+      createMockMdxFile({name: 'untitled-page', route: '/untitled-page'}),
+    ])
+
+    const result = await generateLLMsTxt()
+
+    expect(result).toContain('- [untitled-page](/untitled-page)')
+  })
+
+  it('combines description and keywords in one entry', async () => {
+    mockGetPageMap.mockResolvedValue([
+      createMockMdxFile({name: 'index', route: '/', frontMatter: {title: 'Home'}}),
+      createMockMdxFile({
+        name: 'hero',
+        route: '/hero',
+        frontMatter: {title: 'Hero', description: 'Hero section', keywords: ['banner', 'header']},
+      }),
+    ])
+
+    const result = await generateLLMsTxt()
+
+    expect(result).toContain('- [Hero](/hero): Hero section (banner, header)')
+  })
+
+  it('prepends basePath to routes when NEXT_PUBLIC_DOCTOCAT_BASE_PATH is set', async () => {
+    process.env.NEXT_PUBLIC_DOCTOCAT_BASE_PATH = '/doctocat-nextjs'
+    mockGetPageMap.mockResolvedValue([
+      createMockMdxFile({name: 'index', route: '/', frontMatter: {title: 'Home'}}),
+      createMockMdxFile({name: 'guide', route: '/guide', frontMatter: {title: 'Guide'}}),
+    ])
+
+    const result = await generateLLMsTxt()
+
+    expect(result).toContain('- [Home](/doctocat-nextjs/)')
+    expect(result).toContain('- [Guide](/doctocat-nextjs/guide)')
+  })
+})

--- a/packages/theme/llms.ts
+++ b/packages/theme/llms.ts
@@ -1,0 +1,72 @@
+import {getPageMap} from 'nextra/page-map'
+import type {PageMapItem, MdxFile, Folder} from 'nextra'
+
+function isMdxFile(item: PageMapItem): item is MdxFile {
+  return 'route' in item && 'name' in item && !('children' in item) && !('data' in item)
+}
+
+function isFolder(item: PageMapItem): item is Folder {
+  return 'children' in item
+}
+
+function getTitle(item: MdxFile): string {
+  const title = (item.frontMatter?.title as string) || item.name
+  const tabLabel = item.frontMatter?.['tab-label'] as string | undefined
+  return tabLabel ? `${title} - ${tabLabel}` : title
+}
+
+function getDescription(item: MdxFile): string | undefined {
+  return item.frontMatter?.description as string | undefined
+}
+
+function getKeywords(item: MdxFile): string[] | undefined {
+  const keywords = item.frontMatter?.keywords
+  return Array.isArray(keywords) && keywords.length > 0 ? keywords : undefined
+}
+
+function getPages(items: PageMapItem[]): MdxFile[] {
+  const pages: MdxFile[] = []
+  for (const item of items) {
+    if (isMdxFile(item)) {
+      pages.push(item)
+    } else if (isFolder(item)) {
+      pages.push(...getPages(item.children))
+    }
+  }
+  return pages
+}
+
+export async function generateLLMsTxt(): Promise<string> {
+  const pageMap = await getPageMap()
+  const pages = getPages(pageMap)
+
+  // use homepage to auto-infer site title and descriptions. most users should have filled these out.
+  const homepage = pages.find(page => page.route === '/')
+  const title = (homepage?.frontMatter?.title as string) || process.env.NEXT_PUBLIC_SITE_TITLE || 'Documentation'
+  const description = (homepage?.frontMatter?.description as string) || undefined
+
+  const lines: string[] = [`# ${title}`, '']
+
+  if (description) {
+    lines.push(`> ${description}`, '')
+  }
+
+  lines.push('## Pages', '')
+
+  // start adding all sub pages
+  for (const page of pages) {
+    const pageTitle = getTitle(page)
+    const pageDesc = getDescription(page)
+    const keywords = getKeywords(page)
+    const route = page.route || '/'
+
+    let entry = `- [${pageTitle}](${route})`
+    if (pageDesc) entry += `: ${pageDesc}`
+    if (keywords) entry += ` (${keywords.join(', ')})`
+
+    lines.push(entry)
+  }
+
+  lines.push('')
+  return lines.join('\n')
+}

--- a/packages/theme/llms.ts
+++ b/packages/theme/llms.ts
@@ -1,12 +1,9 @@
 import {getPageMap} from 'nextra/page-map'
-import type {PageMapItem, MdxFile, Folder} from 'nextra'
+import type {PageMapItem, MdxFile} from 'nextra'
+import {hasChildren} from './helpers/hasChildren'
 
 function isMdxFile(item: PageMapItem): item is MdxFile {
   return 'route' in item && 'name' in item && !('children' in item) && !('data' in item)
-}
-
-function isFolder(item: PageMapItem): item is Folder {
-  return 'children' in item
 }
 
 function getTitle(item: MdxFile): string {
@@ -29,7 +26,7 @@ function getPages(items: PageMapItem[]): MdxFile[] {
   for (const item of items) {
     if (isMdxFile(item)) {
       pages.push(item)
-    } else if (isFolder(item)) {
+    } else if (hasChildren(item)) {
       pages.push(...getPages(item.children))
     }
   }
@@ -39,6 +36,7 @@ function getPages(items: PageMapItem[]): MdxFile[] {
 export async function generateLLMsTxt(): Promise<string> {
   const pageMap = await getPageMap()
   const pages = getPages(pageMap)
+  const basePath = process.env.NEXT_PUBLIC_DOCTOCAT_BASE_PATH || ''
 
   // use homepage to auto-infer site title and descriptions. most users should have filled these out.
   const homepage = pages.find(page => page.route === '/')
@@ -58,7 +56,7 @@ export async function generateLLMsTxt(): Promise<string> {
     const pageTitle = getTitle(page)
     const pageDesc = getDescription(page)
     const keywords = getKeywords(page)
-    const route = page.route || '/'
+    const route = `${basePath}${page.route || '/'}`
 
     let entry = `- [${pageTitle}](${route})`
     if (pageDesc) entry += `: ${pageDesc}`


### PR DESCRIPTION
## Summary

Towards https://github.com/github/brand-experience/issues/80

Adds a build-time `llms.txt` generator to the `@primer/doctocat-nextjs` package, which helps agentic AI to more efficiently traverse documentation content. 

🔗 [Example of generated llms.txt for Doctocat docs](https://primer-b84db520be-41738341.drafts.github.io/llms.txt)
🔗 [Example of generated llms.txt for Primer Brand docs](https://primer-d3ffe66d90-26139705.drafts.github.io/brand/llms.txt)

In a before/after test, an Agent (using Opus 4.6) managed to make **36% fewer web requests** when trying to find information on how to use certain components.

This _isn't_ about improving content quality, but about improving token efficiency and discoverability.

## List of notable changes:

- **added** `generateLLMsTxt` export to `@primer/doctocat-nextjs/llms`
- **added** changelog with installation guide

## Steps to test:

1. Verify the llms.txt is being generated in the preview docs

## Supporting resources (related issues, external links, etc):

- [llms.txt specification](https://llmstxt.org/)

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">
<img width="769" height="293" alt="Screenshot 2026-03-17 at 21 29 43" src="https://github.com/user-attachments/assets/4965985a-d162-469d-819a-2e0ef3bae578" />

 </td>
<td valign="top">
<img width="769" height="196" alt="Screenshot 2026-03-17 at 21 26 40" src="https://github.com/user-attachments/assets/e959b17a-16f9-434f-86cd-f3dfcedeeeeb" />

</td>
</tr>
</table>
